### PR TITLE
[update]敵のステート遷移を更新

### DIFF
--- a/NoAlly_ObjectTest/Assets/Enemy/DebugScene.unity
+++ b/NoAlly_ObjectTest/Assets/Enemy/DebugScene.unity
@@ -167,6 +167,135 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &551086229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 551086231}
+  - component: {fileID: 551086230}
+  m_Layer: 0
+  m_Name: EnemyInitializer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &551086230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 551086229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e531dbad53282ec4a965aaf9d70aa508, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _enemyBase:
+  - {fileID: 2035657966}
+--- !u!4 &551086231
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 551086229}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &701827591
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 701827592}
+  - component: {fileID: 701827594}
+  - component: {fileID: 701827593}
+  m_Layer: 0
+  m_Name: Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &701827592
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 701827591}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -1.5, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2035657964}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!23 &701827593
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 701827591}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &701827594
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 701827591}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1003032603
 GameObject:
   m_ObjectHideFlags: 0
@@ -261,6 +390,118 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1148395386
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1148395391}
+  - component: {fileID: 1148395390}
+  - component: {fileID: 1148395389}
+  - component: {fileID: 1148395388}
+  - component: {fileID: 1148395387}
+  m_Layer: 6
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1148395387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148395386}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db1d4b3203180cf4daa1b9ff84d6b39e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _maxHP: 5
+  _invincibleTimeValue: 1
+--- !u!65 &1148395388
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148395386}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1148395389
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148395386}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1148395390
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148395386}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1148395391
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148395386}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -11.08, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1935469111
 GameObject:
   m_ObjectHideFlags: 0
@@ -357,8 +598,9 @@ GameObject:
   - component: {fileID: 2035657963}
   - component: {fileID: 2035657962}
   - component: {fileID: 2035657961}
-  - component: {fileID: 2035657966}
   - component: {fileID: 2035657965}
+  - component: {fileID: 2035657966}
+  - component: {fileID: 2035657967}
   m_Layer: 0
   m_Name: Enemy
   m_TagString: Untagged
@@ -440,7 +682,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 701827592}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -455,7 +698,7 @@ Rigidbody:
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
-  m_UseGravity: 1
+  m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
@@ -469,14 +712,34 @@ MonoBehaviour:
   m_GameObject: {fileID: 2035657960}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 52b2ee828955f62449a690c8032f6876, type: 3}
+  m_Script: {fileID: 11500000, guid: 1b5ddcbc71775a24a99de23996a571f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _objectCollider:
   - {fileID: 2035657961}
   _objectRenderer:
   - {fileID: 2035657962}
-  _objectAnimator: {fileID: 0}
+  _objectAnimator: {fileID: 2035657967}
   _enemyParamater: {fileID: 11400000, guid: a80b4b5d986b5304fbd1ccb387d0578b, type: 2}
   _center: {fileID: 2035657964}
   _rb: {fileID: 2035657965}
+--- !u!95 &2035657967
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2035657960}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 7c965778151bb69428cb43d602aaea25, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0

--- a/NoAlly_ObjectTest/Assets/Enemy/EnemyParamater/Pramater/EnemyParamater.asset
+++ b/NoAlly_ObjectTest/Assets/Enemy/EnemyParamater/Pramater/EnemyParamater.asset
@@ -12,22 +12,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5221f9e3b5033b34094c4471280cf0bb, type: 3}
   m_Name: EnemyParamater
   m_EditorClassIdentifier: 
-  searchRenge: 0
+  searchRenge: 5
   targetLayer:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 64
   hp: 5
   enemyPowers:
-  - defaultPower: 0
-    elementPower: 0
+  - defencePower: 1
     elementType: 0
-  - defaultPower: 0
-    elementPower: 0
-    elementType: 0
-  - defaultPower: 0
-    elementPower: 0
-    elementType: 0
-  - defaultPower: 0
-    elementPower: 0
-    elementType: 0
+  - defencePower: 1
+    elementType: 1
+  - defencePower: 1
+    elementType: 2
+  - defencePower: 1
+    elementType: 3
   speed: 3
+  _attackInterval: 1

--- a/NoAlly_ObjectTest/Assets/Enemy/EnemyParamater/Scripts/EnemyParamaterBase.cs
+++ b/NoAlly_ObjectTest/Assets/Enemy/EnemyParamater/Scripts/EnemyParamaterBase.cs
@@ -14,7 +14,12 @@ public class EnemyParamaterBase : ScriptableObject
     [SerializeField, Header("エネミーの体力")]
     public float hp = 5f;
     [SerializeField, Header("エネミーの攻撃力")]
-    public ObjectPowerValue[] enemyPowers = new ObjectPowerValue[4];
+    public ObjectDefenceValue[] enemyPowers = new ObjectDefenceValue[4];
+
+    [Space(15)]
+
     [SerializeField, Header("エネミーの移動速度")]
     public float speed = 3f;
+    [SerializeField, Range(1f, 5f), Header("エネミーの攻撃速度")]
+    public float _attackInterval = 1f;
 }

--- a/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemyDerivative/CannonEnemy.cs
+++ b/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemyDerivative/CannonEnemy.cs
@@ -8,5 +8,8 @@ public class CannonEnemy : EnemyBase
     protected override void SetActionState()
     {
         base.SetActionState();
+        //プレイヤーへの攻撃
+        _stateMachine.AddTransition<EnemyBattlePosture, FireCannon>((int)StateOfEnemy.NormalAttack);
+        _stateMachine.AddTransition<FireCannon,EnemyBattlePosture > ((int)StateOfEnemy.BattlePosture);
     }
 }

--- a/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemyState/EnemyBattlePosture.cs
+++ b/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemyState/EnemyBattlePosture.cs
@@ -1,40 +1,49 @@
 //日本語コメント可
 using UniRx;
+using UnityEngine;
 using State = StateMachine<EnemyBase>.State;
 
 public class EnemyBattlePosture : State
 {
-    /// <summary>
-    /// 攻撃のアニメーションを再生する　例：エネミーの弾を撃つアニメーションを再生する
-    /// </summary>
-    protected virtual void PlayAttackAnimation() { }
-    /// <summary>
-    /// 攻撃の挙動を処理する　例：エネミーが弾を生成し発射する処理を実行する
-    /// </summary>
-    protected virtual void AttackBehaviour(EnemyAttackEnum attackEnum) { }
+    Interval currentInterval = null;
+    protected override void OnEnter(State prevState)
+    {
+        base.OnEnter(prevState);
+        if (Owner.Player.Value == null)
+        {
+            Owner.EnemyStateMachine.Dispatch((int)StateOfEnemy.Saerching);
+        }
+        else
+        {
+            Owner.ObjectAnimator.SetBool("InSight", true);
+        }
+    }
 
     protected override void OnUpdate()
     {
         base.OnUpdate();
-        PlayAttackAnimation();
+        if (currentInterval.IsCountUp())
+        {
+            Owner.EnemyStateMachine.Dispatch((int)StateOfEnemy.NormalAttack);
+            Debug.Log("攻撃だよ！");
+        }
     }
 
-    protected override void OnTranstion()
+    protected override void OnExit(State nextState)
     {
+        base.OnExit(nextState);
+        currentInterval.ResetTimer();
+    }
+
+    protected override void OnSetUpState()
+    {
+        currentInterval = new(Owner.Paramater._attackInterval);
         Owner.Player
-            .Where(_ => IsActive == true)
+            .Skip(1)
+            .Where(player => player == null && IsActive)
             .Subscribe(player =>
             {
-                if (player == null)
-                {
-                    Owner.EnemyStateMachine.Dispatch((int)StateOfEnemy.Saerching);
-                    Owner.ObjectAnimator.SetBool("InSight", false);
-                }
-            }).AddTo(Owner);
-        Owner.EnemyAttackEnum
-            .Subscribe(attack =>
-            {
-
+                Owner.EnemyStateMachine.Dispatch((int)StateOfEnemy.Saerching);
             }).AddTo(Owner);
     }
 }

--- a/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemyState/EnemySearch.cs
+++ b/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemyState/EnemySearch.cs
@@ -11,10 +11,17 @@ public class EnemySearch : State
     float _turnDuration = 0.5f;
     protected virtual void SearchBehaviour() { }
 
+    protected override void OnEnter(State prevState)
+    {
+        base.OnEnter(prevState);
+        Owner.ObjectAnimator.SetBool("InSight", false);
+    }
+
     protected override void OnUpdate()
     {
         base.OnUpdate();
         SearchBehaviour();
+        EnemyRotate();
     }
 
     protected void EnemyRotate()
@@ -25,25 +32,24 @@ public class EnemySearch : State
             _isRotatedLeft = !_isRotatedLeft;
             if (_isRotatedLeft)
             {
-                Owner.transform.DORotate(new Vector3(0f, -90f, 0f), _turnDuration);
+                Owner.transform.DORotate(new Vector3(0f, 0, 0f), _turnDuration);
             }
             else
             {
-                Owner.transform.DORotate(new Vector3(0f, 90f, 0f), _turnDuration);
+                Owner.transform.DORotate(new Vector3(0f, 180f, 0f), _turnDuration);
             }
             _time = 0;
         }
     }
 
-    protected override void OnTranstion()
+    protected override void OnSetUpState()
     {
-        base.OnTranstion();
+        base.OnSetUpState();
         Owner.Player
             .Where(player => player != null && IsActive)
             .Subscribe(player =>
             {
                 Owner.EnemyStateMachine.Dispatch((int)StateOfEnemy.BattlePosture);
-                Owner.ObjectAnimator.SetBool("InSight", true);
             }).AddTo(Owner);
     }
 }

--- a/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemysSpawnContoller.cs
+++ b/NoAlly_ObjectTest/Assets/Enemy/Scripts/EnemysSpawnContoller.cs
@@ -14,7 +14,6 @@ public class EnemysSpawnContoller : MonoBehaviour,IObjectGenerator
         {
             enemy.DisactiveForInstantiate(this);
             enemy.GetComponent<StatusBase>().Initialize();
-            enemy.Create();
         }
     }
 

--- a/NoAlly_ObjectTest/Assets/Enemy/Scripts/StateOfEnemy.cs
+++ b/NoAlly_ObjectTest/Assets/Enemy/Scripts/StateOfEnemy.cs
@@ -4,10 +4,19 @@ using UnityEngine;
 
 public enum StateOfEnemy : int
 {
-    Idle, //
-    Move, //移動
-    Saerching, //プレイヤーを捜索中
-    BattlePosture, //戦闘態勢
-    Attack, //攻撃
-    Death //死亡
+    None = -1,
+
+    Idle = 0, //基本
+
+    Move = 1, //移動
+
+    Saerching = 2, //プレイヤーを捜索中
+
+    BattlePosture = 3, //戦闘態勢
+
+    Attack = 4, //攻撃
+    NormalAttack = 41, //通常攻撃
+    LoopAttack = 42, //継続的に繰り返す攻撃
+
+    Death = 5 //死亡
 }


### PR DESCRIPTION
## 実装内容
1. 敵の攻撃ステートを通常攻撃と継続攻撃の二種を実装
2. ステートの遷移を確認するテストプレハブを用意

## 改善点
1. 現在攻撃の処理の回数と攻撃を呼び出す回数が一致しないバグが発生しているため要改善
2. 敵が攻撃中にプレイヤーが索敵範囲外に出ても戦闘態勢を解除しないバグが発生しているため要改善